### PR TITLE
Allow raters to nominate contributors during the rating period.

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -35,6 +35,8 @@ It should:
 
 For brevity, wallet authentication information is omitted in the request bodies below. This template will be used to implement wallet auth: https://github.com/NoahSaso/cloudflare-worker-cosmos-auth
 
+All references to a wallet (i.e. `contributor` and `rater` keys) are public keys. This system is not aware of chain addresses at all, as they are derivations of the public key.
+
 ### `POST /:dao`
 
 Create a survey for the DAO, if one is not already active (active determined by the `ratingsCloseAt` date being in the future).

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -29,6 +29,7 @@ It should:
 - allow any DAO member to view ratings for the active survey, once they have submitted their ratings OR once ratings stop being accepted
 - allow any DAO member to record the proposal ID of the created proposal, setting the status to complete, once ratings stop being accepted
 - allow any DAO member to view contributions and ratings from past surveys
+- allow any DAO member to nominate contributions during the rating phase, in case someone did not submit a contribution
 
 ## Routes
 
@@ -113,6 +114,19 @@ Submit a contribution to the active survey. Anyone can do this while contributio
 }
 ```
 
+### `POST /:dao/nominate`
+
+Nominate a contribution to the active survey. Any DAO member can do this while ratings are being accepted.
+
+#### Request
+
+```ts
+{
+  contributor: string
+  contribution: string
+}
+```
+
 ### `POST /:dao/rate`
 
 Submit ratings to the active survey. Any DAO member can do this while ratings are being accepted.
@@ -139,6 +153,7 @@ Fetch contributions for the active survey and this wallet's ratings if submitted
 {
   contributions: {
     id: number
+    nominatedBy: string | null
     contributor: string
     content: string
     createdAt: string
@@ -162,6 +177,7 @@ Fetch contributions and ratings for the active survey. Any DAO member can do thi
 {
   contributions: {
     id: number
+    nominatedBy: string | null
     contributor: string
     content: string
     createdAt: string
@@ -237,6 +253,7 @@ View specific info for a completed survey. Any DAO member can do this.
     }[]
     contributions: {
       id: number
+      nominatedBy: string | null
       contributor: string
       content: string
       createdAt: string
@@ -286,6 +303,7 @@ hasOne Survey
   contributionId: number
   surveyId: number
   contributorPublicKey: string
+  nominatedByPublicKey: string | null
   content: string
 }
 ```

--- a/schema.sql
+++ b/schema.sql
@@ -24,6 +24,7 @@ CREATE TABLE contributions (
   contributionId INTEGER PRIMARY KEY AUTOINCREMENT,
   surveyId INTEGER NOT NULL,
   contributorPublicKey TEXT NOT NULL,
+  nominatedByPublicKey TEXT,
   content TEXT NOT NULL,
   createdAt DATETIME NOT NULL,
   updatedAt DATETIME NOT NULL,

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -51,3 +51,14 @@ export const verifySecp256k1Signature = async (
 
   return await Secp256k1.verifySignature(signature, messageHash, publicKeyData)
 }
+
+// Returns true if the publicKey appears valid (i.e. proper hex encoding and
+// length).
+export const isValidPublicKey = (publicKey: string): boolean => {
+  try {
+    Secp256k1.uncompressPubkey(fromHex(publicKey))
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { getContributions } from './routes/getContributions'
 import { getRatings } from './routes/getRatings'
 import { listCompletedSurveys } from './routes/listCompletedSurveys'
 import { getCompletedSurvey } from './routes/getCompletedSurvey'
+import { submitNomination } from './routes/submitNomination'
 
 // Create CORS handlers.
 const { preflight, corsify } = createCors({
@@ -71,6 +72,14 @@ router.post(
   loadDaoFromParams,
   loadActiveSurveyForDao,
   submitContribution
+)
+// Nominate contribution.
+router.post(
+  '/:dao/nominate',
+  loadDaoFromParams,
+  loadActiveSurveyForDao,
+  authDaoMemberAtSurveyCreationBlockHeightMiddleware,
+  submitNomination
 )
 // Submit ratings.
 router.post(

--- a/src/routes/submitNomination.ts
+++ b/src/routes/submitNomination.ts
@@ -1,3 +1,4 @@
+import { isValidPublicKey } from '../crypto'
 import { AuthorizedRequest, Env, SurveyStatus } from '../types'
 import { respond, respondError } from '../utils'
 import { objectMatchesStructure } from '../utils/objectMatchesStructure'
@@ -33,6 +34,11 @@ export const submitNomination = async (
     !data.contribution.trim()
   ) {
     return respondError(400, 'Missing contributor or contribution.')
+  }
+
+  // Validate contributor public key.
+  if (!isValidPublicKey(data.contributor)) {
+    return respondError(400, 'Invalid contributor public key.')
   }
 
   // If contribution exists, only allow to update this rater initially nominated

--- a/src/routes/submitNomination.ts
+++ b/src/routes/submitNomination.ts
@@ -1,0 +1,71 @@
+import { AuthorizedRequest, Env, SurveyStatus } from '../types'
+import { respond, respondError } from '../utils'
+import { objectMatchesStructure } from '../utils/objectMatchesStructure'
+
+interface SubmitNominationRequest {
+  contributor: string
+  contribution: string
+}
+
+export const submitNomination = async (
+  request: AuthorizedRequest<SubmitNominationRequest>,
+  env: Env
+): Promise<Response> => {
+  const {
+    activeSurvey,
+    parsedBody: { data },
+  } = request
+  // Get active survey.
+  if (!activeSurvey) {
+    return respondError(400, 'There is no active survey.')
+  }
+  // Ensure ratings (thus nominations) are being accepted.
+  if (activeSurvey.status !== SurveyStatus.AcceptingRatings) {
+    return respondError(400, 'Nominations are not being accepted.')
+  }
+
+  if (
+    !objectMatchesStructure(data, {
+      contributor: {},
+      contribution: {},
+    }) ||
+    !data.contributor.trim() ||
+    !data.contribution.trim()
+  ) {
+    return respondError(400, 'Missing contributor or contribution.')
+  }
+
+  // If contribution exists, only allow to update this rater initially nominated
+  // it.
+  const existingContribution = await env.DB.prepare(
+    'SELECT * FROM contributions WHERE surveyId = ?1 AND contributorPublicKey = ?2'
+  )
+    .bind(activeSurvey.surveyId, data.contributor)
+    .first<{ nominatedByPublicKey: string | null } | undefined>()
+  if (
+    existingContribution &&
+    existingContribution.nominatedByPublicKey !== data.auth.publicKey
+  ) {
+    return respondError(
+      404,
+      existingContribution.nominatedByPublicKey === null
+        ? 'Contributor already submitted a contribution.'
+        : 'Contributor already nominated by another rater, so you cannot update their contribution.'
+    )
+  }
+
+  // Make contribution. Updates if already exists.
+  await env.DB.prepare(
+    'INSERT INTO contributions (surveyId, nominatedByPublicKey, contributorPublicKey, content, createdAt, updatedAt) VALUES (?1, ?2, ?3, ?4, ?5, ?5) ON CONFLICT(surveyId, contributorPublicKey) DO UPDATE SET content = ?4, updatedAt = ?5'
+  )
+    .bind(
+      activeSurvey.surveyId,
+      data.auth.publicKey,
+      data.contributor,
+      data.contribution,
+      new Date().toISOString()
+    )
+    .run()
+
+  return respond(200, { success: true })
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,7 @@ export interface Attribute {
 
 export interface Contribution {
   id: number
+  nominatedBy: string | null
   contributor: string
   content: string
   createdAt: string

--- a/src/utils/contribution.ts
+++ b/src/utils/contribution.ts
@@ -2,6 +2,7 @@ import { Contribution, Env } from '../types'
 
 interface ContributionRow {
   id: number
+  nominatedBy: string | null
   contributor: string
   content: string
   createdAt: string
@@ -15,7 +16,7 @@ export const getContributions = async (
   const contributions =
     (
       await DB.prepare(
-        'SELECT contributionId AS id, contributorPublicKey AS contributor, content, createdAt, updatedAt FROM contributions WHERE surveyId = ?1'
+        'SELECT contributionId AS id, nominatedByPublicKey AS nominatedBy, contributorPublicKey AS contributor, content, createdAt, updatedAt FROM contributions WHERE surveyId = ?1'
       )
         .bind(surveyId)
         .all<ContributionRow>()


### PR DESCRIPTION
In case contributors miss the submission period, DAO members should be able to nominate contributors while ratings are open.

Only the rater who nominated a contribution can update that contribution, and a rater cannot override a contribution that already exists.